### PR TITLE
Fix: [AEA-4929] - Fix prescription search request template

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -18,3 +18,5 @@ id-token: write
 0ba20a521167058a74f3b6e65c42d732054e5753:scripts/.*
 root=\"1\.2
 root=\"2\.1
+codeSystem=\"1\.
+codeSystem=\"2\.

--- a/.gitallowed
+++ b/.gitallowed
@@ -16,3 +16,5 @@ id-token: write
 .:src/live-spine-client.*root=*
 0ba20a521167058a74f3b6e65c42d732054e5753:docs.*
 0ba20a521167058a74f3b6e65c42d732054e5753:scripts/.*
+root=\"1\.2
+root=\"2\.1

--- a/.gitallowed
+++ b/.gitallowed
@@ -20,3 +20,4 @@ root=\"1\.2
 root=\"2\.1
 codeSystem=\"1\.
 codeSystem=\"2\.
+2\.16\.840\.1

--- a/src/live-spine-client.ts
+++ b/src/live-spine-client.ts
@@ -49,7 +49,7 @@ interface ClinicalContentViewPartials {
 
 export interface PrescriptionSearchParams {
   requestId: string,
-  prescriptionId: string,
+  prescriptionId?: string,
   organizationId: string,
   sdsRoleProfileId: string,
   sdsId: string,

--- a/src/resources/prescription_search.ts
+++ b/src/resources/prescription_search.ts
@@ -46,7 +46,7 @@ export default `<?xml version="1.0" encoding="utf-8"?>
                     <AgentPersonSDS classCode="AGNT">
                         <id root="1.2.826.0.1285.0.2.0.67" extension="{{agentPersonSDSRoleProfileId}}"/>
                         <agentPersonSDS classCode="PSN" determinerCode="INSTANCE">
-                            <id root="1.2.826.0.1285.0.2.0.65" extension="{{sdsRoleProfileId}}"/>
+                            <id root="1.2.826.0.1285.0.2.0.65" extension="{{agentPersonSDSId}}"/>
                         </agentPersonSDS>
                         <part typeCode="PART">
                             <partSDSRole classCode="ROL">


### PR DESCRIPTION
## Summary
- Routine Change

### Details
- Fixes Author block in prescription search message template
- Updates prescription ID to be optional so that searches can be done via prescription ID or NHS number.